### PR TITLE
Add metrics generation

### DIFF
--- a/resources/metrics/metrics.json
+++ b/resources/metrics/metrics.json
@@ -1,0 +1,1191 @@
+{
+    "loudness": {
+        "min": {
+            "album": {
+                "album_type": "album",
+                "images": [
+                    {
+                        "height": 640,
+                        "url": "https://i.scdn.co/image/ab67616d0000b273558d52de25d11d2589bc60d8",
+                        "width": 640
+                    },
+                    {
+                        "height": 300,
+                        "url": "https://i.scdn.co/image/ab67616d00001e02558d52de25d11d2589bc60d8",
+                        "width": 300
+                    },
+                    {
+                        "height": 64,
+                        "url": "https://i.scdn.co/image/ab67616d00004851558d52de25d11d2589bc60d8",
+                        "width": 64
+                    }
+                ],
+                "name": "Forsvinder",
+                "release_date": "2016-09-17"
+            },
+            "artists": [
+                {
+                    "name": "Bremer/McCoy"
+                }
+            ],
+            "duration_ms": 208500,
+            "explicit": false,
+            "external_urls": {
+                "spotify": "https://open.spotify.com/track/7B4qGax6Rd4fbtDX0eqpHa"
+            },
+            "id": "7B4qGax6Rd4fbtDX0eqpHa",
+            "name": "Ny Begyndelse",
+            "popularity": 30,
+            "features": {
+                "danceability": 0.353,
+                "energy": 0.102,
+                "key": 10,
+                "loudness": -23.769,
+                "mode": 0,
+                "speechiness": 0.0336,
+                "acousticness": 0.967,
+                "instrumentalness": 0.925,
+                "liveness": 0.093,
+                "valence": 0.106,
+                "tempo": 168.167,
+                "type": "audio_features",
+                "id": "7B4qGax6Rd4fbtDX0eqpHa",
+                "uri": "spotify:track:7B4qGax6Rd4fbtDX0eqpHa",
+                "track_href": "https://api.spotify.com/v1/tracks/7B4qGax6Rd4fbtDX0eqpHa",
+                "analysis_url": "https://api.spotify.com/v1/audio-analysis/7B4qGax6Rd4fbtDX0eqpHa",
+                "duration_ms": 208500,
+                "time_signature": 4
+            }
+        },
+        "max": {
+            "album": {
+                "album_type": "single",
+                "images": [
+                    {
+                        "height": 640,
+                        "url": "https://i.scdn.co/image/ab67616d0000b27344aef635102ad58a781bd1a1",
+                        "width": 640
+                    },
+                    {
+                        "height": 300,
+                        "url": "https://i.scdn.co/image/ab67616d00001e0244aef635102ad58a781bd1a1",
+                        "width": 300
+                    },
+                    {
+                        "height": 64,
+                        "url": "https://i.scdn.co/image/ab67616d0000485144aef635102ad58a781bd1a1",
+                        "width": 64
+                    }
+                ],
+                "name": "3rd Ward Bounce",
+                "release_date": "2018-06-01"
+            },
+            "artists": [
+                {
+                    "name": "Big Freedia"
+                },
+                {
+                    "name": "Lizzo"
+                }
+            ],
+            "duration_ms": 185890,
+            "explicit": true,
+            "external_urls": {
+                "spotify": "https://open.spotify.com/track/4nefFqiukTvjgt8hkv73PP"
+            },
+            "id": "4nefFqiukTvjgt8hkv73PP",
+            "name": "Karaoke (feat. Lizzo)",
+            "popularity": 56,
+            "features": {
+                "danceability": 0.736,
+                "energy": 0.967,
+                "key": 2,
+                "loudness": -1.284,
+                "mode": 1,
+                "speechiness": 0.126,
+                "acousticness": 0.0358,
+                "instrumentalness": 0,
+                "liveness": 0.398,
+                "valence": 0.497,
+                "tempo": 103.937,
+                "type": "audio_features",
+                "id": "4nefFqiukTvjgt8hkv73PP",
+                "uri": "spotify:track:4nefFqiukTvjgt8hkv73PP",
+                "track_href": "https://api.spotify.com/v1/tracks/4nefFqiukTvjgt8hkv73PP",
+                "analysis_url": "https://api.spotify.com/v1/audio-analysis/4nefFqiukTvjgt8hkv73PP",
+                "duration_ms": 185890,
+                "time_signature": 4
+            }
+        },
+        "sum": -1697.2469999999994,
+        "avg": -8.12
+    },
+    "tempo": {
+        "min": {
+            "album": {
+                "album_type": "album",
+                "images": [
+                    {
+                        "height": 640,
+                        "url": "https://i.scdn.co/image/ab67616d0000b2734016d72958f2aa2b00df37bf",
+                        "width": 640
+                    },
+                    {
+                        "height": 300,
+                        "url": "https://i.scdn.co/image/ab67616d00001e024016d72958f2aa2b00df37bf",
+                        "width": 300
+                    },
+                    {
+                        "height": 64,
+                        "url": "https://i.scdn.co/image/ab67616d000048514016d72958f2aa2b00df37bf",
+                        "width": 64
+                    }
+                ],
+                "name": "Evergreen",
+                "release_date": "2014-01-01"
+            },
+            "artists": [
+                {
+                    "name": "Broods"
+                }
+            ],
+            "duration_ms": 208346,
+            "explicit": false,
+            "external_urls": {
+                "spotify": "https://open.spotify.com/track/1IcEofBOoS01ouUsqdn8ke"
+            },
+            "id": "1IcEofBOoS01ouUsqdn8ke",
+            "name": "Four Walls",
+            "popularity": 48,
+            "features": {
+                "danceability": 0.511,
+                "energy": 0.638,
+                "key": 0,
+                "loudness": -7.202,
+                "mode": 1,
+                "speechiness": 0.0459,
+                "acousticness": 0.226,
+                "instrumentalness": 0,
+                "liveness": 0.0609,
+                "valence": 0.205,
+                "tempo": 60.03,
+                "type": "audio_features",
+                "id": "1IcEofBOoS01ouUsqdn8ke",
+                "uri": "spotify:track:1IcEofBOoS01ouUsqdn8ke",
+                "track_href": "https://api.spotify.com/v1/tracks/1IcEofBOoS01ouUsqdn8ke",
+                "analysis_url": "https://api.spotify.com/v1/audio-analysis/1IcEofBOoS01ouUsqdn8ke",
+                "duration_ms": 208347,
+                "time_signature": 4
+            }
+        },
+        "max": {
+            "album": {
+                "album_type": "album",
+                "images": [
+                    {
+                        "height": 640,
+                        "url": "https://i.scdn.co/image/ab67616d0000b273b2387adff145bf1995c2ca3d",
+                        "width": 640
+                    },
+                    {
+                        "height": 300,
+                        "url": "https://i.scdn.co/image/ab67616d00001e02b2387adff145bf1995c2ca3d",
+                        "width": 300
+                    },
+                    {
+                        "height": 64,
+                        "url": "https://i.scdn.co/image/ab67616d00004851b2387adff145bf1995c2ca3d",
+                        "width": 64
+                    }
+                ],
+                "name": "Anicca",
+                "release_date": "2019-10-25"
+            },
+            "artists": [
+                {
+                    "name": "Teebs"
+                },
+                {
+                    "name": "Sudan Archives"
+                }
+            ],
+            "duration_ms": 174772,
+            "explicit": false,
+            "external_urls": {
+                "spotify": "https://open.spotify.com/track/2bwRxRvB7VQz7G0BVTYRVc"
+            },
+            "id": "2bwRxRvB7VQz7G0BVTYRVc",
+            "name": "Black Dove",
+            "popularity": 1,
+            "features": {
+                "danceability": 0.252,
+                "energy": 0.734,
+                "key": 5,
+                "loudness": -12.459,
+                "mode": 0,
+                "speechiness": 0.139,
+                "acousticness": 0.000572,
+                "instrumentalness": 0.00145,
+                "liveness": 0.446,
+                "valence": 0.215,
+                "tempo": 202.082,
+                "type": "audio_features",
+                "id": "2bwRxRvB7VQz7G0BVTYRVc",
+                "uri": "spotify:track:2bwRxRvB7VQz7G0BVTYRVc",
+                "track_href": "https://api.spotify.com/v1/tracks/2bwRxRvB7VQz7G0BVTYRVc",
+                "analysis_url": "https://api.spotify.com/v1/audio-analysis/2bwRxRvB7VQz7G0BVTYRVc",
+                "duration_ms": 174773,
+                "time_signature": 3
+            }
+        },
+        "sum": 25107.038000000004,
+        "avg": 120.13
+    },
+    "duration_ms": {
+        "min": {
+            "album": {
+                "album_type": "single",
+                "images": [
+                    {
+                        "height": 640,
+                        "url": "https://i.scdn.co/image/ab67616d0000b273fce4082cf662cefd2fc0237d",
+                        "width": 640
+                    },
+                    {
+                        "height": 300,
+                        "url": "https://i.scdn.co/image/ab67616d00001e02fce4082cf662cefd2fc0237d",
+                        "width": 300
+                    },
+                    {
+                        "height": 64,
+                        "url": "https://i.scdn.co/image/ab67616d00004851fce4082cf662cefd2fc0237d",
+                        "width": 64
+                    }
+                ],
+                "name": "Darkside",
+                "release_date": "2019-07-26"
+            },
+            "artists": [
+                {
+                    "name": "blink-182"
+                }
+            ],
+            "duration_ms": 49146,
+            "explicit": false,
+            "external_urls": {
+                "spotify": "https://open.spotify.com/track/0YDcnsYCut5RFPfgAgjS2T"
+            },
+            "id": "0YDcnsYCut5RFPfgAgjS2T",
+            "name": "Generational Divide",
+            "popularity": 0,
+            "features": {
+                "danceability": 0.343,
+                "energy": 0.974,
+                "key": 5,
+                "loudness": -1.998,
+                "mode": 1,
+                "speechiness": 0.0789,
+                "acousticness": 0.00016,
+                "instrumentalness": 0.000306,
+                "liveness": 0.096,
+                "valence": 0.184,
+                "tempo": 184.901,
+                "type": "audio_features",
+                "id": "0YDcnsYCut5RFPfgAgjS2T",
+                "uri": "spotify:track:0YDcnsYCut5RFPfgAgjS2T",
+                "track_href": "https://api.spotify.com/v1/tracks/0YDcnsYCut5RFPfgAgjS2T",
+                "analysis_url": "https://api.spotify.com/v1/audio-analysis/0YDcnsYCut5RFPfgAgjS2T",
+                "duration_ms": 49147,
+                "time_signature": 4
+            }
+        },
+        "max": {
+            "album": {
+                "album_type": "album",
+                "images": [
+                    {
+                        "height": 640,
+                        "url": "https://i.scdn.co/image/ab67616d0000b273e692562ba9d32ca63bc23665",
+                        "width": 640
+                    },
+                    {
+                        "height": 300,
+                        "url": "https://i.scdn.co/image/ab67616d00001e02e692562ba9d32ca63bc23665",
+                        "width": 300
+                    },
+                    {
+                        "height": 64,
+                        "url": "https://i.scdn.co/image/ab67616d00004851e692562ba9d32ca63bc23665",
+                        "width": 64
+                    }
+                ],
+                "name": "Maim That Tune",
+                "release_date": "1995"
+            },
+            "artists": [
+                {
+                    "name": "Fila Brazillia"
+                }
+            ],
+            "duration_ms": 566146,
+            "explicit": false,
+            "external_urls": {
+                "spotify": "https://open.spotify.com/track/0zaNoKovmrdck2PeLdGpeQ"
+            },
+            "id": "0zaNoKovmrdck2PeLdGpeQ",
+            "name": "A Zed And Two L's",
+            "popularity": 41,
+            "features": {
+                "danceability": 0.467,
+                "energy": 0.173,
+                "key": 1,
+                "loudness": -21.835,
+                "mode": 1,
+                "speechiness": 0.0374,
+                "acousticness": 0.228,
+                "instrumentalness": 0.672,
+                "liveness": 0.0723,
+                "valence": 0.542,
+                "tempo": 99.993,
+                "type": "audio_features",
+                "id": "0zaNoKovmrdck2PeLdGpeQ",
+                "uri": "spotify:track:0zaNoKovmrdck2PeLdGpeQ",
+                "track_href": "https://api.spotify.com/v1/tracks/0zaNoKovmrdck2PeLdGpeQ",
+                "analysis_url": "https://api.spotify.com/v1/audio-analysis/0zaNoKovmrdck2PeLdGpeQ",
+                "duration_ms": 566147,
+                "time_signature": 4
+            }
+        },
+        "sum": 46568256,
+        "avg": 222814.62
+    },
+    "valence": {
+        "min": {
+            "album": {
+                "album_type": "album",
+                "images": [
+                    {
+                        "height": 640,
+                        "url": "https://i.scdn.co/image/ab67616d0000b273fd51e04b98ad30f35b2e183a",
+                        "width": 640
+                    },
+                    {
+                        "height": 300,
+                        "url": "https://i.scdn.co/image/ab67616d00001e02fd51e04b98ad30f35b2e183a",
+                        "width": 300
+                    },
+                    {
+                        "height": 64,
+                        "url": "https://i.scdn.co/image/ab67616d00004851fd51e04b98ad30f35b2e183a",
+                        "width": 64
+                    }
+                ],
+                "name": "If You Wait (Deluxe)",
+                "release_date": "2014-03-25"
+            },
+            "artists": [
+                {
+                    "name": "London Grammar"
+                }
+            ],
+            "duration_ms": 207253,
+            "explicit": false,
+            "external_urls": {
+                "spotify": "https://open.spotify.com/track/7c2D4oHqAUIew44U0vdFhs"
+            },
+            "id": "7c2D4oHqAUIew44U0vdFhs",
+            "name": "Hey Now",
+            "popularity": 33,
+            "features": {
+                "danceability": 0.648,
+                "energy": 0.28,
+                "key": 5,
+                "loudness": -11.961,
+                "mode": 1,
+                "speechiness": 0.0333,
+                "acousticness": 0.396,
+                "instrumentalness": 0.0785,
+                "liveness": 0.106,
+                "valence": 0.0393,
+                "tempo": 120.058,
+                "type": "audio_features",
+                "id": "7c2D4oHqAUIew44U0vdFhs",
+                "uri": "spotify:track:7c2D4oHqAUIew44U0vdFhs",
+                "track_href": "https://api.spotify.com/v1/tracks/7c2D4oHqAUIew44U0vdFhs",
+                "analysis_url": "https://api.spotify.com/v1/audio-analysis/7c2D4oHqAUIew44U0vdFhs",
+                "duration_ms": 207253,
+                "time_signature": 4
+            }
+        },
+        "max": {
+            "album": {
+                "album_type": "single",
+                "images": [
+                    {
+                        "height": 640,
+                        "url": "https://i.scdn.co/image/ab67616d0000b2734d0f642107aa28670c136a52",
+                        "width": 640
+                    },
+                    {
+                        "height": 300,
+                        "url": "https://i.scdn.co/image/ab67616d00001e024d0f642107aa28670c136a52",
+                        "width": 300
+                    },
+                    {
+                        "height": 64,
+                        "url": "https://i.scdn.co/image/ab67616d000048514d0f642107aa28670c136a52",
+                        "width": 64
+                    }
+                ],
+                "name": "Desire",
+                "release_date": "2019-08-27"
+            },
+            "artists": [
+                {
+                    "name": "First Beige"
+                }
+            ],
+            "duration_ms": 249827,
+            "explicit": false,
+            "external_urls": {
+                "spotify": "https://open.spotify.com/track/4J1kq7O9emIDlLO9H4UE6z"
+            },
+            "id": "4J1kq7O9emIDlLO9H4UE6z",
+            "name": "Desire",
+            "popularity": 19,
+            "features": {
+                "danceability": 0.756,
+                "energy": 0.743,
+                "key": 11,
+                "loudness": -8.058,
+                "mode": 1,
+                "speechiness": 0.0519,
+                "acousticness": 0.15,
+                "instrumentalness": 0.749,
+                "liveness": 0.106,
+                "valence": 0.964,
+                "tempo": 115.976,
+                "type": "audio_features",
+                "id": "4J1kq7O9emIDlLO9H4UE6z",
+                "uri": "spotify:track:4J1kq7O9emIDlLO9H4UE6z",
+                "track_href": "https://api.spotify.com/v1/tracks/4J1kq7O9emIDlLO9H4UE6z",
+                "analysis_url": "https://api.spotify.com/v1/audio-analysis/4J1kq7O9emIDlLO9H4UE6z",
+                "duration_ms": 249828,
+                "time_signature": 4
+            }
+        },
+        "sum": 93.24920000000003,
+        "avg": 0.45
+    },
+    "liveness": {
+        "min": {
+            "album": {
+                "album_type": "album",
+                "images": [
+                    {
+                        "height": 640,
+                        "url": "https://i.scdn.co/image/ab67616d0000b273d04a199b0083891937f7cb11",
+                        "width": 640
+                    },
+                    {
+                        "height": 300,
+                        "url": "https://i.scdn.co/image/ab67616d00001e02d04a199b0083891937f7cb11",
+                        "width": 300
+                    },
+                    {
+                        "height": 64,
+                        "url": "https://i.scdn.co/image/ab67616d00004851d04a199b0083891937f7cb11",
+                        "width": 64
+                    }
+                ],
+                "name": "Black Pumas",
+                "release_date": "2019-06-21"
+            },
+            "artists": [
+                {
+                    "name": "Black Pumas"
+                }
+            ],
+            "duration_ms": 197053,
+            "explicit": false,
+            "external_urls": {
+                "spotify": "https://open.spotify.com/track/2RnhLcRnbdXkJ34dCEfFK0"
+            },
+            "id": "2RnhLcRnbdXkJ34dCEfFK0",
+            "name": "Old Man",
+            "popularity": 43,
+            "features": {
+                "danceability": 0.604,
+                "energy": 0.911,
+                "key": 5,
+                "loudness": -7.791,
+                "mode": 1,
+                "speechiness": 0.0423,
+                "acousticness": 0.249,
+                "instrumentalness": 0.000627,
+                "liveness": 0.0501,
+                "valence": 0.962,
+                "tempo": 84.182,
+                "type": "audio_features",
+                "id": "2RnhLcRnbdXkJ34dCEfFK0",
+                "uri": "spotify:track:2RnhLcRnbdXkJ34dCEfFK0",
+                "track_href": "https://api.spotify.com/v1/tracks/2RnhLcRnbdXkJ34dCEfFK0",
+                "analysis_url": "https://api.spotify.com/v1/audio-analysis/2RnhLcRnbdXkJ34dCEfFK0",
+                "duration_ms": 197053,
+                "time_signature": 4
+            }
+        },
+        "max": {
+            "album": {
+                "album_type": "album",
+                "images": [
+                    {
+                        "height": 640,
+                        "url": "https://i.scdn.co/image/ab67616d0000b2736f09f6aa228e82be93be42c6",
+                        "width": 640
+                    },
+                    {
+                        "height": 300,
+                        "url": "https://i.scdn.co/image/ab67616d00001e026f09f6aa228e82be93be42c6",
+                        "width": 300
+                    },
+                    {
+                        "height": 64,
+                        "url": "https://i.scdn.co/image/ab67616d000048516f09f6aa228e82be93be42c6",
+                        "width": 64
+                    }
+                ],
+                "name": "Axe the Cables",
+                "release_date": "2010-06-22"
+            },
+            "artists": [
+                {
+                    "name": "STS9"
+                }
+            ],
+            "duration_ms": 273826,
+            "explicit": false,
+            "external_urls": {
+                "spotify": "https://open.spotify.com/track/4QPvBstnJz1VgW98jsq1jV"
+            },
+            "id": "4QPvBstnJz1VgW98jsq1jV",
+            "name": "Dem Be - Live - Acoustic",
+            "popularity": 15,
+            "features": {
+                "danceability": 0.413,
+                "energy": 0.758,
+                "key": 9,
+                "loudness": -8.305,
+                "mode": 0,
+                "speechiness": 0.0279,
+                "acousticness": 0.616,
+                "instrumentalness": 0.92,
+                "liveness": 0.961,
+                "valence": 0.279,
+                "tempo": 142.699,
+                "type": "audio_features",
+                "id": "4QPvBstnJz1VgW98jsq1jV",
+                "uri": "spotify:track:4QPvBstnJz1VgW98jsq1jV",
+                "track_href": "https://api.spotify.com/v1/tracks/4QPvBstnJz1VgW98jsq1jV",
+                "analysis_url": "https://api.spotify.com/v1/audio-analysis/4QPvBstnJz1VgW98jsq1jV",
+                "duration_ms": 273827,
+                "time_signature": 4
+            }
+        },
+        "sum": 38.44710000000001,
+        "avg": 0.18
+    },
+    "danceability": {
+        "min": {
+            "album": {
+                "album_type": "album",
+                "images": [
+                    {
+                        "height": 640,
+                        "url": "https://i.scdn.co/image/ab67616d0000b2730aac9290fb49635f0f15c37e",
+                        "width": 640
+                    },
+                    {
+                        "height": 300,
+                        "url": "https://i.scdn.co/image/ab67616d00001e020aac9290fb49635f0f15c37e",
+                        "width": 300
+                    },
+                    {
+                        "height": 64,
+                        "url": "https://i.scdn.co/image/ab67616d000048510aac9290fb49635f0f15c37e",
+                        "width": 64
+                    }
+                ],
+                "name": "The Much Much How How and I (Deluxe Edition)",
+                "release_date": "2019-04-05"
+            },
+            "artists": [
+                {
+                    "name": "Cosmo Sheldrake"
+                }
+            ],
+            "duration_ms": 336320,
+            "explicit": false,
+            "external_urls": {
+                "spotify": "https://open.spotify.com/track/3ZqFdHInxTmbx7rHSitxAc"
+            },
+            "id": "3ZqFdHInxTmbx7rHSitxAc",
+            "name": "Linger Longer",
+            "popularity": 28,
+            "features": {
+                "danceability": 0.22,
+                "energy": 0.428,
+                "key": 10,
+                "loudness": -10.829,
+                "mode": 0,
+                "speechiness": 0.0443,
+                "acousticness": 0.763,
+                "instrumentalness": 0.796,
+                "liveness": 0.0757,
+                "valence": 0.217,
+                "tempo": 79.967,
+                "type": "audio_features",
+                "id": "3ZqFdHInxTmbx7rHSitxAc",
+                "uri": "spotify:track:3ZqFdHInxTmbx7rHSitxAc",
+                "track_href": "https://api.spotify.com/v1/tracks/3ZqFdHInxTmbx7rHSitxAc",
+                "analysis_url": "https://api.spotify.com/v1/audio-analysis/3ZqFdHInxTmbx7rHSitxAc",
+                "duration_ms": 336320,
+                "time_signature": 3
+            }
+        },
+        "max": {
+            "album": {
+                "album_type": "single",
+                "images": [
+                    {
+                        "height": 640,
+                        "url": "https://i.scdn.co/image/ab67616d0000b27321ca58a5e42becdf2557649d",
+                        "width": 640
+                    },
+                    {
+                        "height": 300,
+                        "url": "https://i.scdn.co/image/ab67616d00001e0221ca58a5e42becdf2557649d",
+                        "width": 300
+                    },
+                    {
+                        "height": 64,
+                        "url": "https://i.scdn.co/image/ab67616d0000485121ca58a5e42becdf2557649d",
+                        "width": 64
+                    }
+                ],
+                "name": "Lil Bit",
+                "release_date": "2019-06-29"
+            },
+            "artists": [
+                {
+                    "name": "No-uh"
+                }
+            ],
+            "duration_ms": 172617,
+            "explicit": true,
+            "external_urls": {
+                "spotify": "https://open.spotify.com/track/1zkd1MmJtXzuDJiqZlExVm"
+            },
+            "id": "1zkd1MmJtXzuDJiqZlExVm",
+            "name": "Lil Bit",
+            "popularity": 39,
+            "features": {
+                "danceability": 0.97,
+                "energy": 0.61,
+                "key": 6,
+                "loudness": -6.144,
+                "mode": 0,
+                "speechiness": 0.142,
+                "acousticness": 0.0149,
+                "instrumentalness": 0,
+                "liveness": 0.0795,
+                "valence": 0.926,
+                "tempo": 113.007,
+                "type": "audio_features",
+                "id": "1zkd1MmJtXzuDJiqZlExVm",
+                "uri": "spotify:track:1zkd1MmJtXzuDJiqZlExVm",
+                "track_href": "https://api.spotify.com/v1/tracks/1zkd1MmJtXzuDJiqZlExVm",
+                "analysis_url": "https://api.spotify.com/v1/audio-analysis/1zkd1MmJtXzuDJiqZlExVm",
+                "duration_ms": 172617,
+                "time_signature": 4
+            }
+        },
+        "sum": 126.61699999999996,
+        "avg": 0.61
+    },
+    "energy": {
+        "min": {
+            "album": {
+                "album_type": "album",
+                "images": [
+                    {
+                        "height": 640,
+                        "url": "https://i.scdn.co/image/ab67616d0000b273558d52de25d11d2589bc60d8",
+                        "width": 640
+                    },
+                    {
+                        "height": 300,
+                        "url": "https://i.scdn.co/image/ab67616d00001e02558d52de25d11d2589bc60d8",
+                        "width": 300
+                    },
+                    {
+                        "height": 64,
+                        "url": "https://i.scdn.co/image/ab67616d00004851558d52de25d11d2589bc60d8",
+                        "width": 64
+                    }
+                ],
+                "name": "Forsvinder",
+                "release_date": "2016-09-17"
+            },
+            "artists": [
+                {
+                    "name": "Bremer/McCoy"
+                }
+            ],
+            "duration_ms": 208500,
+            "explicit": false,
+            "external_urls": {
+                "spotify": "https://open.spotify.com/track/7B4qGax6Rd4fbtDX0eqpHa"
+            },
+            "id": "7B4qGax6Rd4fbtDX0eqpHa",
+            "name": "Ny Begyndelse",
+            "popularity": 30,
+            "features": {
+                "danceability": 0.353,
+                "energy": 0.102,
+                "key": 10,
+                "loudness": -23.769,
+                "mode": 0,
+                "speechiness": 0.0336,
+                "acousticness": 0.967,
+                "instrumentalness": 0.925,
+                "liveness": 0.093,
+                "valence": 0.106,
+                "tempo": 168.167,
+                "type": "audio_features",
+                "id": "7B4qGax6Rd4fbtDX0eqpHa",
+                "uri": "spotify:track:7B4qGax6Rd4fbtDX0eqpHa",
+                "track_href": "https://api.spotify.com/v1/tracks/7B4qGax6Rd4fbtDX0eqpHa",
+                "analysis_url": "https://api.spotify.com/v1/audio-analysis/7B4qGax6Rd4fbtDX0eqpHa",
+                "duration_ms": 208500,
+                "time_signature": 4
+            }
+        },
+        "max": {
+            "album": {
+                "album_type": "single",
+                "images": [
+                    {
+                        "height": 640,
+                        "url": "https://i.scdn.co/image/ab67616d0000b273fce4082cf662cefd2fc0237d",
+                        "width": 640
+                    },
+                    {
+                        "height": 300,
+                        "url": "https://i.scdn.co/image/ab67616d00001e02fce4082cf662cefd2fc0237d",
+                        "width": 300
+                    },
+                    {
+                        "height": 64,
+                        "url": "https://i.scdn.co/image/ab67616d00004851fce4082cf662cefd2fc0237d",
+                        "width": 64
+                    }
+                ],
+                "name": "Darkside",
+                "release_date": "2019-07-26"
+            },
+            "artists": [
+                {
+                    "name": "blink-182"
+                }
+            ],
+            "duration_ms": 49146,
+            "explicit": false,
+            "external_urls": {
+                "spotify": "https://open.spotify.com/track/0YDcnsYCut5RFPfgAgjS2T"
+            },
+            "id": "0YDcnsYCut5RFPfgAgjS2T",
+            "name": "Generational Divide",
+            "popularity": 0,
+            "features": {
+                "danceability": 0.343,
+                "energy": 0.974,
+                "key": 5,
+                "loudness": -1.998,
+                "mode": 1,
+                "speechiness": 0.0789,
+                "acousticness": 0.00016,
+                "instrumentalness": 0.000306,
+                "liveness": 0.096,
+                "valence": 0.184,
+                "tempo": 184.901,
+                "type": "audio_features",
+                "id": "0YDcnsYCut5RFPfgAgjS2T",
+                "uri": "spotify:track:0YDcnsYCut5RFPfgAgjS2T",
+                "track_href": "https://api.spotify.com/v1/tracks/0YDcnsYCut5RFPfgAgjS2T",
+                "analysis_url": "https://api.spotify.com/v1/audio-analysis/0YDcnsYCut5RFPfgAgjS2T",
+                "duration_ms": 49147,
+                "time_signature": 4
+            }
+        },
+        "sum": 130.20000000000007,
+        "avg": 0.62
+    },
+    "popularity": {
+        "min": {
+            "album": {
+                "album_type": "single",
+                "images": [
+                    {
+                        "height": 640,
+                        "url": "https://i.scdn.co/image/ab67616d0000b2735f672b7418cf5a013f0a7b25",
+                        "width": 640
+                    },
+                    {
+                        "height": 300,
+                        "url": "https://i.scdn.co/image/ab67616d00001e025f672b7418cf5a013f0a7b25",
+                        "width": 300
+                    },
+                    {
+                        "height": 64,
+                        "url": "https://i.scdn.co/image/ab67616d000048515f672b7418cf5a013f0a7b25",
+                        "width": 64
+                    }
+                ],
+                "name": "Back To Life",
+                "release_date": "2019-06-17"
+            },
+            "artists": [
+                {
+                    "name": "Fergus James"
+                }
+            ],
+            "duration_ms": 200201,
+            "explicit": false,
+            "external_urls": {
+                "spotify": "https://open.spotify.com/track/2CJadAfhWsD1wNH3egy09x"
+            },
+            "id": "2CJadAfhWsD1wNH3egy09x",
+            "name": "Back To Life",
+            "popularity": 0,
+            "features": {
+                "danceability": 0.412,
+                "energy": 0.917,
+                "key": 7,
+                "loudness": -5.252,
+                "mode": 0,
+                "speechiness": 0.236,
+                "acousticness": 0.0346,
+                "instrumentalness": 5.09e-06,
+                "liveness": 0.109,
+                "valence": 0.144,
+                "tempo": 169.988,
+                "type": "audio_features",
+                "id": "2CJadAfhWsD1wNH3egy09x",
+                "uri": "spotify:track:2CJadAfhWsD1wNH3egy09x",
+                "track_href": "https://api.spotify.com/v1/tracks/2CJadAfhWsD1wNH3egy09x",
+                "analysis_url": "https://api.spotify.com/v1/audio-analysis/2CJadAfhWsD1wNH3egy09x",
+                "duration_ms": 200201,
+                "time_signature": 4
+            }
+        },
+        "max": {
+            "album": {
+                "album_type": "single",
+                "images": [
+                    {
+                        "height": 640,
+                        "url": "https://i.scdn.co/image/ab67616d0000b273447289301b37e205337ddd61",
+                        "width": 640
+                    },
+                    {
+                        "height": 300,
+                        "url": "https://i.scdn.co/image/ab67616d00001e02447289301b37e205337ddd61",
+                        "width": 300
+                    },
+                    {
+                        "height": 64,
+                        "url": "https://i.scdn.co/image/ab67616d00004851447289301b37e205337ddd61",
+                        "width": 64
+                    }
+                ],
+                "name": "FIRE ON MARZZ",
+                "release_date": "2019-06-28"
+            },
+            "artists": [
+                {
+                    "name": "BENEE"
+                }
+            ],
+            "duration_ms": 180146,
+            "explicit": false,
+            "external_urls": {
+                "spotify": "https://open.spotify.com/track/23TPP1eeElFfvYVznskwCY"
+            },
+            "id": "23TPP1eeElFfvYVznskwCY",
+            "name": "Glitter",
+            "popularity": 78,
+            "features": {
+                "danceability": 0.801,
+                "energy": 0.589,
+                "key": 7,
+                "loudness": -5.157,
+                "mode": 1,
+                "speechiness": 0.0485,
+                "acousticness": 0.0863,
+                "instrumentalness": 0,
+                "liveness": 0.162,
+                "valence": 0.58,
+                "tempo": 116.934,
+                "type": "audio_features",
+                "id": "23TPP1eeElFfvYVznskwCY",
+                "uri": "spotify:track:23TPP1eeElFfvYVznskwCY",
+                "track_href": "https://api.spotify.com/v1/tracks/23TPP1eeElFfvYVznskwCY",
+                "analysis_url": "https://api.spotify.com/v1/audio-analysis/23TPP1eeElFfvYVznskwCY",
+                "duration_ms": 180147,
+                "time_signature": 4
+            }
+        },
+        "sum": 7286,
+        "avg": 34.86
+    },
+    "instrumentalness": {
+        "min": {
+            "album": {
+                "album_type": "single",
+                "images": [
+                    {
+                        "height": 640,
+                        "url": "https://i.scdn.co/image/ab67616d0000b27369b4d7f351f084ac249891f1",
+                        "width": 640
+                    },
+                    {
+                        "height": 300,
+                        "url": "https://i.scdn.co/image/ab67616d00001e0269b4d7f351f084ac249891f1",
+                        "width": 300
+                    },
+                    {
+                        "height": 64,
+                        "url": "https://i.scdn.co/image/ab67616d0000485169b4d7f351f084ac249891f1",
+                        "width": 64
+                    }
+                ],
+                "name": "Suburbia",
+                "release_date": "2019-06-21"
+            },
+            "artists": [
+                {
+                    "name": "Order Sixty6"
+                }
+            ],
+            "duration_ms": 210961,
+            "explicit": true,
+            "external_urls": {
+                "spotify": "https://open.spotify.com/track/3x8US7nlhXtgGPrvV976T2"
+            },
+            "id": "3x8US7nlhXtgGPrvV976T2",
+            "name": "Suburbia",
+            "popularity": 8,
+            "features": {
+                "danceability": 0.755,
+                "energy": 0.577,
+                "key": 1,
+                "loudness": -6.612,
+                "mode": 0,
+                "speechiness": 0.379,
+                "acousticness": 0.241,
+                "instrumentalness": 0,
+                "liveness": 0.094,
+                "valence": 0.809,
+                "tempo": 156.058,
+                "type": "audio_features",
+                "id": "3x8US7nlhXtgGPrvV976T2",
+                "uri": "spotify:track:3x8US7nlhXtgGPrvV976T2",
+                "track_href": "https://api.spotify.com/v1/tracks/3x8US7nlhXtgGPrvV976T2",
+                "analysis_url": "https://api.spotify.com/v1/audio-analysis/3x8US7nlhXtgGPrvV976T2",
+                "duration_ms": 210962,
+                "time_signature": 4
+            }
+        },
+        "max": {
+            "album": {
+                "album_type": "single",
+                "images": [
+                    {
+                        "height": 640,
+                        "url": "https://i.scdn.co/image/ab67616d0000b273aa574cddb2d648311e6ac3a7",
+                        "width": 640
+                    },
+                    {
+                        "height": 300,
+                        "url": "https://i.scdn.co/image/ab67616d00001e02aa574cddb2d648311e6ac3a7",
+                        "width": 300
+                    },
+                    {
+                        "height": 64,
+                        "url": "https://i.scdn.co/image/ab67616d00004851aa574cddb2d648311e6ac3a7",
+                        "width": 64
+                    }
+                ],
+                "name": "Vega",
+                "release_date": "2017-06-16"
+            },
+            "artists": [
+                {
+                    "name": "il:lo"
+                }
+            ],
+            "duration_ms": 219000,
+            "explicit": false,
+            "external_urls": {
+                "spotify": "https://open.spotify.com/track/6gnXuVRUWzH2irUgwCXpdz"
+            },
+            "id": "6gnXuVRUWzH2irUgwCXpdz",
+            "name": "Opale",
+            "popularity": 22,
+            "features": {
+                "danceability": 0.593,
+                "energy": 0.745,
+                "key": 11,
+                "loudness": -7.51,
+                "mode": 0,
+                "speechiness": 0.0314,
+                "acousticness": 0.0132,
+                "instrumentalness": 0.958,
+                "liveness": 0.442,
+                "valence": 0.0559,
+                "tempo": 118.022,
+                "type": "audio_features",
+                "id": "6gnXuVRUWzH2irUgwCXpdz",
+                "uri": "spotify:track:6gnXuVRUWzH2irUgwCXpdz",
+                "track_href": "https://api.spotify.com/v1/tracks/6gnXuVRUWzH2irUgwCXpdz",
+                "analysis_url": "https://api.spotify.com/v1/audio-analysis/6gnXuVRUWzH2irUgwCXpdz",
+                "duration_ms": 219000,
+                "time_signature": 4
+            }
+        },
+        "sum": 30.675899899999987,
+        "avg": 0.15
+    },
+    "acousticness": {
+        "min": {
+            "album": {
+                "album_type": "album",
+                "images": [
+                    {
+                        "height": 640,
+                        "url": "https://i.scdn.co/image/ab67616d0000b273785e5c1944ac09df047834ea",
+                        "width": 640
+                    },
+                    {
+                        "height": 300,
+                        "url": "https://i.scdn.co/image/ab67616d00001e02785e5c1944ac09df047834ea",
+                        "width": 300
+                    },
+                    {
+                        "height": 64,
+                        "url": "https://i.scdn.co/image/ab67616d00004851785e5c1944ac09df047834ea",
+                        "width": 64
+                    }
+                ],
+                "name": "And Now For The Whatchamacallit",
+                "release_date": "2019-05-31"
+            },
+            "artists": [
+                {
+                    "name": "Psychedelic Porn Crumpets"
+                }
+            ],
+            "duration_ms": 207453,
+            "explicit": false,
+            "external_urls": {
+                "spotify": "https://open.spotify.com/track/1dnkljuEh79HyaKJu9N8cp"
+            },
+            "id": "1dnkljuEh79HyaKJu9N8cp",
+            "name": "Hymn For A Droid",
+            "popularity": 33,
+            "features": {
+                "danceability": 0.393,
+                "energy": 0.91,
+                "key": 5,
+                "loudness": -4.613,
+                "mode": 0,
+                "speechiness": 0.0624,
+                "acousticness": 2.94e-05,
+                "instrumentalness": 0.44,
+                "liveness": 0.318,
+                "valence": 0.251,
+                "tempo": 140.062,
+                "type": "audio_features",
+                "id": "1dnkljuEh79HyaKJu9N8cp",
+                "uri": "spotify:track:1dnkljuEh79HyaKJu9N8cp",
+                "track_href": "https://api.spotify.com/v1/tracks/1dnkljuEh79HyaKJu9N8cp",
+                "analysis_url": "https://api.spotify.com/v1/audio-analysis/1dnkljuEh79HyaKJu9N8cp",
+                "duration_ms": 207453,
+                "time_signature": 4
+            }
+        },
+        "max": {
+            "album": {
+                "album_type": "single",
+                "images": [
+                    {
+                        "height": 640,
+                        "url": "https://i.scdn.co/image/ab67616d0000b2738a129baedb4c323bd8e87647",
+                        "width": 640
+                    },
+                    {
+                        "height": 300,
+                        "url": "https://i.scdn.co/image/ab67616d00001e028a129baedb4c323bd8e87647",
+                        "width": 300
+                    },
+                    {
+                        "height": 64,
+                        "url": "https://i.scdn.co/image/ab67616d000048518a129baedb4c323bd8e87647",
+                        "width": 64
+                    }
+                ],
+                "name": "Let's Go",
+                "release_date": "2017-10-23"
+            },
+            "artists": [
+                {
+                    "name": "In Love With a Ghost"
+                },
+                {
+                    "name": "Nori"
+                }
+            ],
+            "duration_ms": 252121,
+            "explicit": false,
+            "external_urls": {
+                "spotify": "https://open.spotify.com/track/5VnaOLeK1lKfULuNwet8ck"
+            },
+            "id": "5VnaOLeK1lKfULuNwet8ck",
+            "name": "Flowers",
+            "popularity": 63,
+            "features": {
+                "danceability": 0.641,
+                "energy": 0.24,
+                "key": 8,
+                "loudness": -19.107,
+                "mode": 1,
+                "speechiness": 0.047,
+                "acousticness": 0.979,
+                "instrumentalness": 0.866,
+                "liveness": 0.234,
+                "valence": 0.32,
+                "tempo": 99.02,
+                "type": "audio_features",
+                "id": "5VnaOLeK1lKfULuNwet8ck",
+                "uri": "spotify:track:5VnaOLeK1lKfULuNwet8ck",
+                "track_href": "https://api.spotify.com/v1/tracks/5VnaOLeK1lKfULuNwet8ck",
+                "analysis_url": "https://api.spotify.com/v1/audio-analysis/5VnaOLeK1lKfULuNwet8ck",
+                "duration_ms": 252121,
+                "time_signature": 4
+            }
+        },
+        "sum": 58.19461069999997,
+        "avg": 0.28
+    }
+}

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ install_requirements = [
     "six~=1.12",
     "google-cloud-storage",
     "beautifulsoup4",
+    "requests",
 ]
 
 test_requirements = [
@@ -20,12 +21,12 @@ setup(
     name="FourTrackFriday",
     version="0.1",
     packages=find_packages(),
-    url="fourtrackfriday.com",
+    url="https://4trackfriday.com",
     license="",
     author="Michael Tanner",
     author_email="tanner.mbt@gmail.com",
     description="Code for Four Track Friday Content Creation",
     install_requires=install_requirements,
     extras_require={"tests": [test_requirements]},
-    entry_points={"console_scripts": ["ftf_content=src.app.main:main"]},
+    entry_points={"console_scripts": ["ftf_content=src.main:main"]},
 )

--- a/src/aws_uploader.py
+++ b/src/aws_uploader.py
@@ -2,5 +2,5 @@ from src.uploader import Uploader
 
 
 class AWSUploader(Uploader):
-    def upload(self, path_to_file) -> None:
+    def upload_episode(self, path_to_file) -> None:
         pass

--- a/src/batch_scripts.py
+++ b/src/batch_scripts.py
@@ -24,5 +24,5 @@ def batch_upload():
     uploader = GCloudUploader(config=ConfigManager())
     for file in os.listdir("resources/polished_episodes"):
         print(f"Uploading {file}...")
-        uploader.upload(f"resources/polished_episodes/{file}")
-        uploader.tag(f"resources/polished_episodes/{file}")
+        uploader.upload_episode(f"resources/polished_episodes/{file}")
+        uploader.tag_episode(f"resources/polished_episodes/{file}")

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -6,3 +6,5 @@ class ConfigManager:
         self.cloud_provider = os.environ["CLOUD_PROVIDER"]  # raises error if not found
         self.gcloud_project = os.environ.get("GCLOUD_PROJECT")
         self.static_4tf_bucket = os.environ.get("STATIC_4TF_BUCKET")
+        self.spotify_client_id = os.environ.get("SPOTIFY_CLIENT_ID")
+        self.spotify_client_secret = os.environ.get("SPOTIFY_CLIENT_SECRET")

--- a/src/gcloud_uploader.py
+++ b/src/gcloud_uploader.py
@@ -11,14 +11,25 @@ class GCloudUploader(Uploader):
             bucket_name=config.static_4tf_bucket
         )
 
-    def upload(self, path_to_file: str) -> None:
+    def upload_episode(self, path_to_file: str) -> None:
         file_name = self.get_file_name(path_to_file)
         with open(path_to_file, "rb") as html_file:
             storage.blob.Blob(
                 name=f"episodes/{file_name}", bucket=self.bucket
             ).upload_from_file(file_obj=html_file, content_type="text/html")
 
-    def tag(self, path_to_file: str) -> None:
+    def upload_metrics(self, path_to_file: str):
+        file_name = self.get_file_name(path_to_file)
+        with open(path_to_file, "rb") as html_file:
+            storage.blob.Blob(
+                name=f"playlist_stats/{file_name}", bucket=self.bucket
+            ).upload_from_file(file_obj=html_file, content_type="application/json")
+
+    @staticmethod
+    def get_file_name(path_to_file: str) -> str:
+        return path_to_file.split("/")[-1]
+
+    def tag_episode(self, path_to_file: str) -> None:
         file_name = self.get_file_name(path_to_file)
         with open(path_to_file, "r") as html_file:
             soup = BeautifulSoup(html_file, "html.parser")
@@ -32,7 +43,3 @@ class GCloudUploader(Uploader):
             "date": date,
         }
         blob.patch()
-
-    @staticmethod
-    def get_file_name(path_to_file: str) -> str:
-        return path_to_file.split("/")[-1]

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 import os
 
+from src.spotify_handler import SpotifyHandler
 from src.config_manager import ConfigManager
 from src.fetcher_factory import FetcherFactory
 from src.sender import Sender
@@ -9,6 +10,9 @@ from src.content_merger import merge
 
 def main(episode_name: str) -> None:
     config = ConfigManager()
+
+    spotify_handler = SpotifyHandler(config=config)
+    spotify_handler.generate_per_feature_metrics()
 
     fetcher = FetcherFactory(config=config).get_fetcher()
     subscribers = fetcher.fetch_test_subscribers()
@@ -28,13 +32,14 @@ def main(episode_name: str) -> None:
     )
 
     uploader = UploaderFactory(config=config).get_uploader()
-    uploader.upload(
+    uploader.upload_episode(
         path_to_file=os.path.join("resources/polished_episodes", f"{episode_name}.html")
     )
-    uploader.tag(
+    uploader.tag_episode(
         path_to_file=os.path.join("resources/polished_episodes", f"{episode_name}.html")
     )
+    uploader.upload_metrics(path_to_file="resources/metrics/metrics.json")
 
 
 if __name__ == "__main__":
-    main(episode_name="20_06_26")
+    main(episode_name="")

--- a/src/spotify_handler.py
+++ b/src/spotify_handler.py
@@ -1,0 +1,210 @@
+import base64
+import json
+
+import requests
+
+from config_manager import ConfigManager
+
+
+class SpotifyHandler:
+    def __init__(self, config: ConfigManager):
+        self.config = config
+        self.playlist_id = "720360kMd4LiSAVzyA8Ft4"
+        self.base_request_uri = "https://api.spotify.com/v1/"
+        self.base_authz_uri = "https://accounts.spotify.com/api/token"
+        self.cached_token = None
+        self.feature_set = {
+            "acousticness",
+            "danceability",
+            "duration_ms",
+            "energy",
+            "instrumentalness",
+            "liveness",
+            "loudness",
+            "tempo",
+            "popularity",
+            "valence",
+        }
+        self.overview_data = self._get_playlist_overview()
+        self.playlist_tracks_data = self._get_playlist_tracks()
+        self.track_dict = self._build_track_dict(self.playlist_tracks_data)
+        self.track_features = self._get_track_features(list(self.track_dict.keys()))
+        self.playlist_info = self._get_playlist_info()
+
+    @property
+    def token(self):
+        if not self.cached_token:
+            response = requests.post(
+                self.base_authz_uri,
+                headers={"Authorization": f"Basic {self._encoded_spotify_auth()}"},
+                data={"grant_type": "client_credentials"},
+            )
+            if response.status_code != 200:
+                return None
+
+            self.cached_token = response.json()["access_token"]
+        return self.cached_token
+
+    def _encoded_spotify_auth(self):
+        return base64.b64encode(
+            (
+                self.config.spotify_client_id + ":" + self.config.spotify_client_secret
+            ).encode("utf-8")
+        ).decode("utf-8")
+
+    def _get_playlist_info(self):
+        """
+        Fetch data from Spotify API and build the playlist json data structure
+        """
+        for each in self.track_features:
+            track_id = each["id"]
+            self.track_dict[track_id]["features"] = each
+        overview_dict = {k: v for k, v in self.overview_data.items()}
+        overview_dict["playlist_count"] = len(self.track_dict.keys())
+        overview_dict["track_breakdown"] = self.track_dict
+
+        return overview_dict
+
+    def _get_playlist_overview(self):
+        overview_params = (
+            "name,description,followers,owner(display_name),external_urls(spotify)"
+        )
+
+        response = requests.get(
+            self.base_request_uri + f"playlists/{self.playlist_id}",
+            headers={"Authorization": f"Bearer {self.token}"},
+            params={"fields": overview_params},
+        )
+        if response.status_code != 200:
+            return "error fetching playlist overview"
+
+        return response.json()
+
+    def _get_playlist_tracks(self):
+        """
+        Get paginated data for all tracks
+        """
+        album_params = "album(name,release_date,images,album_type)"
+        artist_params = "artists(name)"
+        track_params = (
+            "limit,next,offset,total,href,items(added_at,"
+            f"track({album_params},{artist_params},name,release_date,duration_ms,explicit,external_urls,popularity,id))"
+        )
+
+        track_list = []
+        response = requests.get(
+            self.base_request_uri + f"playlists/{self.playlist_id}/tracks",
+            headers={"Authorization": f"Bearer {self.token}"},
+            params={"fields": track_params},
+        )
+
+        if response.status_code == 200:
+            track_dict = response.json()
+            track_list.extend(track_dict["items"])
+            while track_dict["next"]:
+                response = requests.get(
+                    track_dict["next"],
+                    headers={"Authorization": f"Bearer {self.token}"},
+                    params={"fields": track_params},
+                )
+                if response.status_code == 200:
+                    track_dict = response.json()
+                    track_list.extend(track_dict["items"])
+
+        return track_list
+
+    def _get_track_features(self, song_ids):
+        """
+        Example response
+            {
+            "audio_features": [
+              {
+                "acousticness": 0.135,
+                "analysis_url": "https://api.spotify.com/v1/audio-analysis/1PR1JQmuOmI3eD4isHeLlI",
+                "danceability": 0.722,
+                "duration_ms": 158276,
+                "energy": 0.574,
+                "id": "1PR1JQmuOmI3eD4isHeLlI",
+                "instrumentalness": 0.000865,
+                "key": 10,
+                "liveness": 0.163,
+                "loudness": -5.72,
+                "mode": 0,
+                "speechiness": 0.179,
+                "tempo": 104.983,
+                "time_signature": 4,
+                "track_href": "https://api.spotify.com/v1/tracks/1PR1JQmuOmI3eD4isHeLlI",
+                "type": "audio_features",
+                "uri": "spotify:track:1PR1JQmuOmI3eD4isHeLlI",
+                "valence": 0.337
+              },
+            }
+        """
+        pagination_list = [song_ids[i : i + 100] for i in range(0, len(song_ids), 100)]
+        feature_list = []
+        for songs in pagination_list:
+            song_string = ",".join(songs)
+
+            resp = requests.get(
+                self.base_request_uri + "audio-features",
+                headers={"Authorization": f"Bearer {self.token}"},
+                params={"ids": song_string},
+            )
+            feature_list.extend(resp.json()["audio_features"])
+
+        return feature_list
+
+    @staticmethod
+    def _build_track_dict(playlist_arr):
+        track_dict = {}
+        for track in playlist_arr:
+            track_id = track["track"]["id"]
+            track_dict[track_id] = track["track"]
+        return track_dict
+
+    def generate_per_feature_metrics(self):
+        start_key = next(iter(self.playlist_info["track_breakdown"]))
+        default_track = self.playlist_info["track_breakdown"].get(start_key)
+
+        feature_map = dict.fromkeys(self.feature_set)
+        for k, v in feature_map.items():
+            feature_map[k] = {
+                "min": default_track,
+                "max": default_track,
+                "sum": 0,
+                "avg": 0,
+            }
+
+        # find the min, max, and avg for each feature
+        for k, v in self.playlist_info["track_breakdown"].items():
+            for feature_key, feature_val in feature_map.items():
+                if feature_key == "popularity":
+                    curr_feature = v[feature_key]
+                    if curr_feature < feature_map[feature_key]["min"][feature_key]:
+                        feature_map[feature_key]["min"] = v
+                    if curr_feature > feature_map[feature_key]["max"][feature_key]:
+                        feature_map[feature_key]["max"] = v
+                    feature_map[feature_key]["sum"] += curr_feature
+                else:
+                    curr_feature = v["features"][feature_key]
+                    if (
+                        curr_feature
+                        < feature_map[feature_key]["min"]["features"][feature_key]
+                    ):
+                        feature_map[feature_key]["min"] = v
+                    if (
+                        curr_feature
+                        > feature_map[feature_key]["max"]["features"][feature_key]
+                    ):
+                        feature_map[feature_key]["max"] = v
+                    feature_map[feature_key]["sum"] += curr_feature
+
+        for k, v in feature_map.items():
+            feature_map[k]["avg"] = round(
+                feature_map[k]["sum"]
+                / len(self.playlist_info["track_breakdown"].keys()),
+                2,
+            )
+
+        with open("./resources/metrics/metrics.json", "w+", encoding="utf-8") as f:
+            json.dump(feature_map, f, ensure_ascii=False, indent=4)

--- a/src/uploader.py
+++ b/src/uploader.py
@@ -3,5 +3,5 @@ import abc
 
 class Uploader(metaclass=abc.ABCMeta):
     @abc.abstractmethod
-    def upload(self, path_to_file: str) -> None:
+    def upload_episode(self, path_to_file: str) -> None:
         raise NotImplementedError


### PR DESCRIPTION
### Relevance

This is a new feature for 4TrackFriday, enabling the exploration of various musical features that are exposed by the Spotify API.

### What is this PR trying to accomplish?

Provide access to those features and store the results in a common place (a bucket) for the web app companion to use.

### What should I know before reviewing this PR?

That Spotify provides [developer documentation](https://developer.spotify.com/discover/).

### How do I know this works?

Local testing